### PR TITLE
removed unused scopes in authentication

### DIFF
--- a/backend/src/connectors/spotifyService.ts
+++ b/backend/src/connectors/spotifyService.ts
@@ -23,6 +23,7 @@ export default class SpotifyService {
   private static readonly scopes: string[] = [
     'ugc-image-upload',
     'playlist-modify-private',
+    'playlist-modify-public',
     'playlist-read-private',
     'playlist-modify-public',
     'playlist-read-collaborative',
@@ -36,11 +37,12 @@ export default class SpotifyService {
     'user-read-playback-position',
     'user-read-recently-played',
     'user-top-read',
-    'app-remote-control',
     'streaming',
-    'user-follow-modify',
-    'user-follow-read',
-  ]; // TODO
+    // Currently we do not use these 3:
+    // 'app-remote-control',
+    // 'user-follow-modify',
+    // 'user-follow-read',
+  ];
 
   private spotifyApi: SpotifyWebApi;
 


### PR DESCRIPTION
As David mentioned, we should avoid fetching user data that our app does not use!

I went through all the requests we use and the player sdk uses and compared it to the list of scopes.
There are three scopes we do not currently need. Those are commented out, in case we need them later.

1 Review is enough! 

closes #253 