### PR TITLE
Fix bug "remove tagtracklist when tag is deleted"

### DIFF
--- a/frontend/src/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/components/Dashboard/Dashboard.tsx
@@ -76,7 +76,9 @@ export class DashboardService {
     const newAlbums = currentDashboard.albums.filter((a) => a.id !== id);
     DashboardService.saveCurrentDashboardState({...currentDashboard, albums: newAlbums});
 
-    NotificationsService.push('success', 'Removed album from start page');
+    if (currentDashboard.albums.length !== newAlbums.length) {
+      NotificationsService.push('success', 'Removed album from start page');
+    }
   }
 
   static containsAlbum(id: string) {
@@ -100,12 +102,25 @@ export class DashboardService {
     const newPlaylists = currentDashboard.playlists.filter((p) => p.id !== id);
     DashboardService.saveCurrentDashboardState({...currentDashboard, playlists: newPlaylists});
 
-    NotificationsService.push('success', 'Removed playlist from start page');
+    if (currentDashboard.playlists.length !== newPlaylists.length) {
+      NotificationsService.push('success', 'Removed playlist from start page');
+    }
   }
 
   static containsPlaylist(id: string) {
     const currentDashboard = DashboardService.getCurrentDashboardState();
     return currentDashboard.playlists.some((p) => p.id === id);
+  }
+
+  // TagTracklists methods
+  static removeTagTracklist(id: string) {
+    const currentDashboard = DashboardService.getCurrentDashboardState();
+    const newTagTracklists = currentDashboard.tagTracklists.filter((p) => p.id !== id);
+    DashboardService.saveCurrentDashboardState({...currentDashboard, tagTracklists: newTagTracklists});
+
+    if (currentDashboard.tagTracklists.length !== newTagTracklists.length) {
+      NotificationsService.push('success', 'Removed tag tracklist from start page');
+    }
   }
 
   // Helper methods

--- a/frontend/src/utils/tags-system.tsx
+++ b/frontend/src/utils/tags-system.tsx
@@ -1,3 +1,5 @@
+import {DashboardService} from "../components/Dashboard/Dashboard";
+
 const LOCALSTORAGE_KEY = 'tags';
 
 export interface TagData {
@@ -77,8 +79,12 @@ export default class TagsSystem {
       [key: string]: string[],
     } = {};
 
+    // Remove tag from elements
     Object.entries(tags.spotifyElements).forEach((e) => newSpotifyElements[e[0]] = e[1].filter((id) => id !== tagId));
     tags.spotifyElements = newSpotifyElements;
+
+    // Remove tag from start page
+    DashboardService.removeTagTracklist(tagId);
 
     TagsSystem.saveTags(tags);
   }


### PR DESCRIPTION
when a tag is deleted from the tag system and a tag tracklist of that tag exists on the startpage, it will be deleted from the startpage

closes #286 