### PR TITLE
feature/350-startpage-menu-scroll

### DIFF
--- a/frontend/src/components/Dashboard/Dashboard.scss
+++ b/frontend/src/components/Dashboard/Dashboard.scss
@@ -17,7 +17,7 @@
   flex-flow: row wrap;
   margin-bottom: $spacer;
   padding: 1rem;
-  position: sticky;
+  position: relative;
   top: 0;
   z-index: 1;
 


### PR DESCRIPTION
das menü muss weg scrollen, weil es zu groß ist, sonst kann man die seite nicht richtig anpassen