### PR TITLE
fix album track fetching

### DIFF
--- a/frontend/src/components/Album/Album.tsx
+++ b/frontend/src/components/Album/Album.tsx
@@ -115,7 +115,7 @@ export default function Album(props: IProps) {
 
   // Fetch more album tracks if necessary
   useEffect(() => {
-    fetchAlbumTrackData(offset);
+    if (album) fetchAlbumTrackData(offset);
   }, [offset]);
 
   if (!album) {


### PR DESCRIPTION
Only for albums with more than 20 tracks:
It would happen that the [offset] effect was run before the main fetchAlbumData(), which results in a false track order or even duplicate tracks.
<img width="1067" alt="Bildschirmfoto 2022-02-08 um 20 01 59" src="https://user-images.githubusercontent.com/52577845/153059426-68f42fb6-6e9f-4373-a239-6848c2edee1a.png">


alternate solution is increasing the ```const limit = 20;``` to 50 (is there a reason for it being 20?)
