### PR TITLE
Bugfix/273 reload player on theme toggle

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -64,7 +64,7 @@ function App() {
     if (wasPlaying) {
       setTimeout(() => {
         startPlaying();
-      }, 1500);
+      }, 2000);
     }
   };
 


### PR DESCRIPTION
workaround as discussed on monday: player triggers playback after 2s if it was playing before theme switch

closes #273 