### PR TITLE
scroll fetching fix for chrome

### DIFF
--- a/frontend/src/components/Albums/Albums.tsx
+++ b/frontend/src/components/Albums/Albums.tsx
@@ -45,7 +45,7 @@ export default function Albums() {
 
   //fetch next albums when you reach the bottom of the current list
   const onScroll = (e: any) => {
-    const bottom = e.target.scrollHeight - e.target.scrollTop === e.target.clientHeight;
+    const bottom = Math.abs(e.target.scrollHeight - e.target.scrollTop - e.target.clientHeight) < 2;
     if (bottom && albums && albums.offset < albums.total) {
       const limit = albums.limit;
       const offset = albums.offset + limit;

--- a/frontend/src/components/Playlists/Playlists.tsx
+++ b/frontend/src/components/Playlists/Playlists.tsx
@@ -89,7 +89,7 @@ export default function Playlists() {
 
   //fetch next playlists when you reach the bottom of the current list
   const onScroll = (e: any) => {
-    const bottom = e.target.scrollHeight - e.target.scrollTop === e.target.clientHeight;
+    const bottom = Math.abs(e.target.scrollHeight - e.target.scrollTop - e.target.clientHeight) < 2;
     if (bottom && playlists && playlists.offset < playlists.total) {
       const limit = playlists.limit;
       const offset = playlists.offset + limit;


### PR DESCRIPTION
sometimes the scrollTop value was something with .5 for some reason, because of that it would never completely reach "bottom"

this should fix it