### PR TITLE
fix double notification when adding playlist to startpage

### DIFF
--- a/frontend/src/components/ContextMenu/PlaylistsMenu.tsx
+++ b/frontend/src/components/ContextMenu/PlaylistsMenu.tsx
@@ -137,13 +137,9 @@ function PlaylistsMenu(props: Props) {
     if (isOnStartpage) {
       DashboardService.removePlaylist(props.data.id);
       setIsOnStartpage(false);
-
-      NotificationsService.push("success", "Added playlist to start page");
     } else {
       DashboardService.addPlaylist(props.data.id);
       setIsOnStartpage(true);
-
-      NotificationsService.push("success", "Removed playlist from start page");
     }
   };
 


### PR DESCRIPTION
removed notification in playlist menu because it is sent in service already

closes #384 