### PR TITLE
add scroll on tags overflow without scrollbar

### DIFF
--- a/frontend/src/components/TrackList/TrackList.scss
+++ b/frontend/src/components/TrackList/TrackList.scss
@@ -196,6 +196,7 @@
       overflow-x: scroll;
       scrollbar-width: none;
       -ms-overflow-style: none;
+      cursor: ew-resize;
 
       &::-webkit-scrollbar {
         display: none;


### PR DESCRIPTION
tested in chrome, firefox, safari

closes #400 